### PR TITLE
add function to enable a clean require in a single call

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,3 +14,13 @@ var clear = module.exports = function (moduleId) {
 clear.all = function () {
 	Object.keys(require.cache).forEach(clear);
 };
+
+clear.require = function (moduleId) {
+	clear(moduleId);
+
+	var mod = require(moduleId);
+
+	clear(moduleId);
+
+	return mod;
+};

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,11 @@ What you would put into `require()`.
 
 Clear all modules from the require cache.
 
+### clearRequire.require(moduleId)
+
+Returns a clean require of the given moduleId. Does not add the returned module
+to require.cache.
+
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -15,3 +15,12 @@ test('clearRequire.all()', function (t) {
 	clearRequire.all();
 	t.assert(Object.keys(require.cache).length === 0);
 });
+
+test('clearRequire.require()', function (t) {
+	var id = './fixture';
+	t.assert(require(id)() === 1);
+	t.assert(require(id)() === 2);
+	t.assert(clearRequire.require(id)() === 1);
+	t.assert(Object.keys(require.cache).length === 0);
+	t.assert(require(id)() === 1);
+});


### PR DESCRIPTION
I thought it'd be nice to be able to write the below:

```js
var foo = clearRequire.require('./foo')
```

vs.

```js
clearRequire('./foo')
var foo = require('./foo')
```

Perhaps this crosses a grey area of "we don't ever want to replace require, just an easy way to clean it". It's useful for testing purposes however.