### PR TITLE
Add regex based clear

### DIFF
--- a/fixture-match.js
+++ b/fixture-match.js
@@ -1,0 +1,6 @@
+'use strict';
+var i = 0;
+
+module.exports = function () {
+  return ++i;
+};

--- a/index.js
+++ b/index.js
@@ -14,3 +14,9 @@ var clear = module.exports = function (moduleId) {
 clear.all = function () {
 	Object.keys(require.cache).forEach(clear);
 };
+
+clear.match = function (regex) {
+  Object.keys(require.cache).forEach(function (moduleId) {
+    if (regex.test(moduleId)) clear(moduleId);
+  })
+};

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Clear a module from the require cache.
 
 #### moduleId
 
-*Required*  
+*Required*
 Type: `string`
 
 What you would put into `require()`.
@@ -55,6 +55,14 @@ What you would put into `require()`.
 
 Clear all modules from the require cache.
 
+### clearRequire.match(regex)
+
+Clear all modules from the require cache that match the regex.
+
+#### regex
+
+*Required*
+Type: `/pattern/` or `RegExp` object
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -15,3 +15,13 @@ test('clearRequire.all()', function (t) {
 	clearRequire.all();
 	t.assert(Object.keys(require.cache).length === 0);
 });
+
+test('clearRequire.match()', function (t) {
+  var id = './fixture';
+  var match = './fixture-match';
+  t.assert(require(id)() === 1);
+  t.assert(require(match)() === 1);
+  clearRequire.match(/fixture-match/);
+  t.assert(require(id)() === 2);
+  t.assert(require(match)() === 1);
+});


### PR DESCRIPTION
Allows you to clear only a few specific modules from cache in cases where calling clear one by one is not an option or purging the whole cache is not what you want to do.

E.g. clearing all moment and its locales

```
clear.match(/moment[\\/]/);

// clears 

// /path/to/node_modules/moment
// /path/to/node_modules/moment/locale/...
```